### PR TITLE
Fix data preview for SQLite and LLM prompt typo

### DIFF
--- a/NLDQS-MCP/app/app.py
+++ b/NLDQS-MCP/app/app.py
@@ -153,7 +153,7 @@ async def query(request: Request):
 
 
         prompt = f"""
-        ou are a database query assistant. Please convert the user's natural language question into a PostgreSQL query statement.
+        You are a database query assistant. Please convert the user's natural language question into a PostgreSQL query statement.
 
             📌 Table: query_anything.{table_name}
 


### PR DESCRIPTION
## Summary
- allow SQLite previews for NL query system
- fix small prompt typo in MCP version of the app

## Testing
- `python -m py_compile NLDQS/app/app.py NLDQS-MCP/app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6863be82c188832393e3fe0bde404994