### PR TITLE
Add PostGIS client for MCP

### DIFF
--- a/MCP_911Fire_NLQS/README.md
+++ b/MCP_911Fire_NLQS/README.md
@@ -1,1 +1,34 @@
 ### Notion : https://www.notion.so/911-MCP-20eb7bf10bf880268b7adc15bd8be62e?source=copy_link
+
+This directory hosts the assets for the 911Fire NLQS demo.
+
+## MCP Client
+
+`app/mcp_client.py` provides a small helper to communicate with Ollama's Model Context Protocol service.
+`app/postgis_mcp_client.py` extends the client with PostGIS helpers.
+
+Example usage:
+
+```python
+from mcp_client import MCPClient
+
+client = MCPClient("http://localhost:11434")
+ctx = client.create_context("demo", "system instructions")
+response = client.generate(ctx["id"], "你好嗎？")
+print(response["response"])
+```
+### PostGIS Example
+
+```python
+from postgis_mcp_client import PostGISMCPClient
+
+pg_client = PostGISMCPClient(base_url="http://localhost:11434")
+ctx = pg_client.create_geo_context(
+    name="fire-calls",
+    table="public.fire_calls",
+    instructions="Describe the incidents",
+    limit=10,
+)
+result = pg_client.generate(ctx["id"], "附近有幾個火警？")
+print(result["response"])
+```

--- a/MCP_911Fire_NLQS/app/mcp_client.py
+++ b/MCP_911Fire_NLQS/app/mcp_client.py
@@ -1,0 +1,62 @@
+import requests
+from typing import Iterator, Dict, Any
+
+class MCPClient:
+    """Simple client for Ollama's Model Context Protocol (MCP).
+
+    Parameters
+    ----------
+    base_url : str
+        Base URL of the Ollama server (e.g. "http://localhost:11434").
+    """
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        self.base_url = base_url.rstrip("/")
+
+    # Context management -------------------------------------------------
+    def create_context(self, name: str, instructions: str) -> Dict[str, Any]:
+        """Create a new MCP context."""
+        payload = {"name": name, "instructions": instructions}
+        resp = requests.post(f"{self.base_url}/api/mcp/context", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_context(self, context_id: str, instructions: str) -> Dict[str, Any]:
+        """Update an existing MCP context."""
+        payload = {"instructions": instructions}
+        resp = requests.put(f"{self.base_url}/api/mcp/context/{context_id}", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_context(self, context_id: str) -> Dict[str, Any]:
+        """Fetch a context's metadata."""
+        resp = requests.get(f"{self.base_url}/api/mcp/context/{context_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_context(self, context_id: str) -> None:
+        """Delete an MCP context."""
+        resp = requests.delete(f"{self.base_url}/api/mcp/context/{context_id}")
+        resp.raise_for_status()
+
+    # Generation ---------------------------------------------------------
+    def generate(
+        self,
+        context_id: str,
+        prompt: str,
+        stream: bool = False,
+    ) -> Iterator[str] | Dict[str, Any]:
+        """Generate text using a specific MCP context."""
+        payload = {
+            "context": context_id,
+            "prompt": prompt,
+            "stream": stream,
+        }
+        resp = requests.post(f"{self.base_url}/api/mcp/generate", json=payload, stream=stream)
+        resp.raise_for_status()
+        if stream:
+            for line in resp.iter_lines(decode_unicode=True):
+                if line:
+                    yield line
+        else:
+            return resp.json()

--- a/MCP_911Fire_NLQS/app/postgis_mcp_client.py
+++ b/MCP_911Fire_NLQS/app/postgis_mcp_client.py
@@ -1,0 +1,97 @@
+import psycopg2
+import requests
+from typing import Iterator, Dict, Any, List
+
+
+class PostGISMCPClient:
+    """Client integrating PostGIS queries with Ollama's Model Context Protocol.
+
+    Parameters
+    ----------
+    dbname : str
+        Name of the PostGIS database.
+    user : str
+        Database user name.
+    password : str
+        Password for the database user.
+    host : str
+        Hostname of the PostGIS server.
+    port : str
+        Port of the PostGIS server.
+    base_url : str
+        Base URL of the Ollama server (e.g. ``"http://localhost:11434"``).
+    """
+
+    def __init__(
+        self,
+        dbname: str = "mydatabase",
+        user: str = "user",
+        password: str = "123456",
+        host: str = "postgres_service",
+        port: str = "5432",
+        base_url: str = "http://localhost:11434",
+    ) -> None:
+        self.db_params = {
+            "dbname": dbname,
+            "user": user,
+            "password": password,
+            "host": host,
+            "port": port,
+        }
+        self.base_url = base_url.rstrip("/")
+
+    # ------------------------------------------------------------------
+    # PostGIS helpers
+    def _connect(self):
+        return psycopg2.connect(**self.db_params)
+
+    def fetch_geojson(self, table: str, geom_col: str = "geom", limit: int = 100) -> List[str]:
+        """Return GeoJSON geometries from the specified table."""
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute(
+            f"SELECT ST_AsGeoJSON({geom_col}) FROM {table} LIMIT %s", (limit,)
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [row[0] for row in rows]
+
+    # ------------------------------------------------------------------
+    # MCP wrappers
+    def create_context(self, name: str, instructions: str) -> Dict[str, Any]:
+        payload = {"name": name, "instructions": instructions}
+        resp = requests.post(f"{self.base_url}/api/mcp/context", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def generate(
+        self,
+        context_id: str,
+        prompt: str,
+        stream: bool = False,
+    ) -> Iterator[str] | Dict[str, Any]:
+        payload = {"context": context_id, "prompt": prompt, "stream": stream}
+        resp = requests.post(
+            f"{self.base_url}/api/mcp/generate", json=payload, stream=stream
+        )
+        resp.raise_for_status()
+        if stream:
+            for line in resp.iter_lines(decode_unicode=True):
+                if line:
+                    yield line
+        else:
+            return resp.json()
+
+    def create_geo_context(
+        self,
+        name: str,
+        table: str,
+        instructions: str,
+        geom_col: str = "geom",
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        """Create a context using GeoJSON data from a PostGIS table."""
+        features = self.fetch_geojson(table, geom_col, limit)
+        joined = "\n".join(features)
+        full_instructions = f"{instructions}\n\nGeoJSON:\n{joined}"
+        return self.create_context(name, full_instructions)

--- a/NLDQS-MCP/README.md
+++ b/NLDQS-MCP/README.md
@@ -112,3 +112,16 @@ http://localhost:3000
 - [ ] 使用 shadcn/ui 美化元件
 
 ---
+## 🏗 MCP 客戶端
+
+`mcp_client.py` 提供與 Ollama Model Context Protocol 通訊的基本封裝，範例用法：
+
+```python
+from mcp_client import MCPClient
+
+client = MCPClient("http://localhost:11434")
+ctx = client.create_context("demo", "system instructions")
+response = client.generate(ctx["id"], "你好嗎？")
+print(response["response"])
+```
+

--- a/NLDQS-MCP/app/mcp_client.py
+++ b/NLDQS-MCP/app/mcp_client.py
@@ -1,0 +1,67 @@
+import requests
+from typing import Iterator, Optional, Dict, Any
+
+
+class MCPClient:
+    """Simple client for Ollama's Model Context Protocol (MCP).
+
+    Parameters
+    ----------
+    base_url : str
+        Base URL of the Ollama server (e.g. ``"http://localhost:11434"``).
+    """
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        self.base_url = base_url.rstrip("/")
+
+    # Context management -----------------------------------------------------
+    def create_context(self, name: str, instructions: str) -> Dict[str, Any]:
+        """Create a new MCP context."""
+        payload = {"name": name, "instructions": instructions}
+        resp = requests.post(f"{self.base_url}/api/mcp/context", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_context(self, context_id: str, instructions: str) -> Dict[str, Any]:
+        """Update an existing MCP context."""
+        payload = {"instructions": instructions}
+        resp = requests.put(
+            f"{self.base_url}/api/mcp/context/{context_id}", json=payload
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_context(self, context_id: str) -> Dict[str, Any]:
+        """Fetch a context's metadata."""
+        resp = requests.get(f"{self.base_url}/api/mcp/context/{context_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_context(self, context_id: str) -> None:
+        """Delete an MCP context."""
+        resp = requests.delete(f"{self.base_url}/api/mcp/context/{context_id}")
+        resp.raise_for_status()
+
+    # Generation -------------------------------------------------------------
+    def generate(
+        self,
+        context_id: str,
+        prompt: str,
+        stream: bool = False,
+    ) -> Iterator[str] | Dict[str, Any]:
+        """Generate text using a specific MCP context."""
+        payload = {
+            "context": context_id,
+            "prompt": prompt,
+            "stream": stream,
+        }
+        resp = requests.post(
+            f"{self.base_url}/api/mcp/generate", json=payload, stream=stream
+        )
+        resp.raise_for_status()
+        if stream:
+            for line in resp.iter_lines(decode_unicode=True):
+                if line:
+                    yield line
+        else:
+            return resp.json()


### PR DESCRIPTION
## Summary
- extend the 911Fire demo by adding `postgis_mcp_client.py`
- document the new PostGIS-based client in the README with example usage

## Testing
- `python -m py_compile MCP_911Fire_NLQS/app/mcp_client.py MCP_911Fire_NLQS/app/postgis_mcp_client.py`
- `python -m py_compile NLDQS-MCP/app/*.py NLDQS/app/app.py NLDQS/app/backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6863c0dca6508323bc7e8352c2c4645b